### PR TITLE
Remove subtitle line break, update Dockerfile to use Node.js 20, add Electrolize font to head.html, and ensure proper loading in toolbox-main.scss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 WORKDIR /usr/src/app
 

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ const {
 /* ************** Options ************** */
 
 const initialTheme = {
+    textAlign: "center",
     ...getAllPresets()[15],
     background: "#62518d",
     borderSize: 5,

--- a/partials/head.html
+++ b/partials/head.html
@@ -43,8 +43,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Kalam&display=swap" rel="preload" as="style"
         crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css2?family=Kalam&display=swap" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Electrolize&display=swap" rel="preload" as="style"
+        crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Electrolize&display=swap" rel="stylesheet" crossorigin="anonymous">
     <link
-        href="https://fonts.googleapis.com/css2?family=Anonymous+Pro&family=Athiti&family=Della+Respira&family=Electrolize&family=Kalam&family=Lancelot&family=Life+Savers&family=Maven+Pro&family=Passero+One&family=Pixelify+Sans&family=Playball&family=Poppins&family=Quattrocento&family=Red+Hat+Display&family=Source+Code+Pro&family=Ubuntu&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Anonymous+Pro&family=Athiti&family=Della+Respira&family=Kalam&family=Lancelot&family=Life+Savers&family=Maven+Pro&family=Passero+One&family=Pixelify+Sans&family=Playball&family=Poppins&family=Quattrocento&family=Red+Hat+Display&family=Source+Code+Pro&family=Ubuntu&display=swap"
         rel="stylesheet">
 
     <!-- Favicon -->

--- a/styles/toolbox-main.scss
+++ b/styles/toolbox-main.scss
@@ -55,6 +55,13 @@
             .title,
             .subtitle {
                 transition: 0.25s ease;
+                white-space: nowrap;
+            }
+
+            // Ensure Electrolize font loads properly
+            .title[style*="Electrolize"],
+            .subtitle[style*="Electrolize"] {
+                font-family: "Electrolize", monospace !important;
             }
 
             img {


### PR DESCRIPTION
# Fix Subtitle Line Break and Font Loading Issues

## Description

This PR addresses multiple UI and compatibility issues in the GitHub Profile Header Generator:

1. **Subtitle text wrapping**: Fixes the issue where subtitle text would break to a second line instead of staying on a single line
2. **Font loading reliability**: Ensures the Electrolize font loads properly without falling back to serif fonts
3. **Build compatibility**: Updates Node.js version for better compatibility with the current Vite version
4. **Default text alignment**: Improves the initial user experience with centered text alignment

These changes improve the overall user experience by ensuring text displays correctly and fonts load reliably across different browsers and environments.

## Changes

1. **Fix subtitle text wrapping**: Added `white-space: nowrap` CSS property to prevent subtitle text from breaking to multiple lines
2. **Update Node.js version**: Changed Dockerfile from `node:18-alpine` to `node:20-alpine` for Vite 7 compatibility
3. **Improve Electrolize font loading**: 
   - Added separate preload and stylesheet links for Electrolize font
   - Removed Electrolize from the combined Google Fonts URL to prevent conflicts
   - Added CSS fallback rules with `font-family: "Electrolize", monospace !important`
4. **Set default text alignment**: Added `textAlign: "center"` to the initial theme for better default positioning

## Screenshots

_Before: Subtitle text breaking to second line_
![Before](https://private-user-images.githubusercontent.com/83970685/504153327-df3468f0-1ee6-4dfb-8cf9-ec92c03128d2.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjExNDU0NjcsIm5iZiI6MTc2MTE0NTE2NywicGF0aCI6Ii84Mzk3MDY4NS81MDQxNTMzMjctZGYzNDY4ZjAtMWVlNi00ZGZiLThjZjktZWM5MmMwMzEyOGQyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDIyVDE0NTkyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWUzZDNhYTI5NzA4MWVjY2Q3MWZhYWUzYjBiNGNkOWVhYzNlNGQxZjI2NGE5NGY2NGFmMGU4NDBlZDY4MmIwMjUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.zN6zAsO7Iwj4p4Fdv0z1EWCDVpbzidTrexUrpOTOgYs)

_After: Subtitle text stays on single line_
<img width="1860" height="504" alt="github-header-banner (1)" src="https://github.com/user-attachments/assets/83e6a531-a016-4db4-a78d-7c03e7e1ed01" />

## Related Issues

This PR:
- Fixes subtitle text wrapping issue where the last word would appear on a second line
- Resolves Electrolize font loading issues that caused fallback to serif fonts
- Addresses build compatibility issues with Node.js 18 and Vite 7

## Additional Information

- **Testing**: The changes have been tested in the Docker environment and verified to work correctly
- **Browser compatibility**: Font loading improvements ensure consistent behavior across different browsers
- **Performance**: Separate font preloading improves initial page load performance
- **Backwards compatibility**: All changes are additive and don't break existing functionality