### PR TITLE
Fix typo: 'projecy' -> 'project'

### DIFF
--- a/partials/how-to.html
+++ b/partials/how-to.html
@@ -15,7 +15,7 @@
                 <b>this guide</b>.
             </a>
         </li>
-        <li>Upload your header to your profile/projecy repo.</li>
+        <li>Upload your header to your profile/project repo.</li>
         <li>
             Add this line to your README:
             <p class="code"><code>![Header](./your-header-image-name.png)</code></p>


### PR DESCRIPTION
# Fix typo in homepage: "projecy" → "project"

## Description
This PR corrects a small typo in the usage instructions. The word "projecy" was mistakenly used instead of "project." Fixing this improves clarity and professionalism of the website.

## Changes
1. Fixed typo in Step 3 of the "How to use it?" section.
   - Changed: `profile/projecy repo`
   - To: `profile/project repo`

## Screenshots
Fixed - Screenshot
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/1628f4ea-c75a-4b1f-bd95-513230e1b0ff" />


## Related Issues
This PR addresses the typo reported in the issue:
- Fixes #31 

## Additional Information
No functional changes were made. This small fix improves readability and avoids confusion for new users following the setup guide.